### PR TITLE
Shorter request keys and removed '_' from key string

### DIFF
--- a/rediscache.js
+++ b/rediscache.js
@@ -9,7 +9,7 @@ module.exports = function(Model, options) {
     var redis = require("redis"),
         client = redis.createClient(clientSettings);
 
-    var redisDeletePattern = require('redis-delete-pattern'); 
+    var redisDeletePattern = require('redis-delete-pattern');
 
     client.on("error", function (err) {
         console.log(err);
@@ -17,7 +17,7 @@ module.exports = function(Model, options) {
         if(err.toString().indexOf("invalid password") !== -1){
             console.log("Invalid password... reconnecting with server config...");
             var app = require('../../server/server');
-            var clientSettings = app.get('redis');        
+            var clientSettings = app.get('redis');
             client = redis.createClient(clientSettings);
         }
     });
@@ -31,7 +31,10 @@ module.exports = function(Model, options) {
                 var cachExpire = ctx.req.query.cache;
 
                 // set key name
-                var cache_key = modelName+'_'+new Buffer(JSON.stringify(ctx.req.query)).toString('base64');
+                var crypto = require('crypto');
+                var request_key = new Buffer(JSON.stringify(ctx.req.query)).toString('base64');
+                request_key = crypto.createHash('md5').update(request_key).digest("hex");
+                var cache_key = modelName +'_' + request_key;
 
                 // search for cache
                 client.get(cache_key, function(err, val) {
@@ -47,16 +50,16 @@ module.exports = function(Model, options) {
                     }else{
                         //return data
                         next();
-                    }                
-                });    
+                    }
+                });
 
             }else{
                 next();
             }
         }else{
             next();
-        }            
-    });    
+        }
+    });
 
     Model.afterRemote('**', function(ctx, res, next) {
         // get all find methods and search first in cache - if not exist save in cache
@@ -64,9 +67,12 @@ module.exports = function(Model, options) {
             if(typeof ctx.req.query.cache != 'undefined'){
                 var modelName = ctx.method.sharedClass.name;
                 var cachExpire = ctx.req.query.cache;
-                
+
                 // set key name
-                var cache_key = modelName+'_'+new Buffer(JSON.stringify(ctx.req.query)).toString('base64');
+                var crypto = require('crypto');
+                var request_key = new Buffer(JSON.stringify(ctx.req.query)).toString('base64');
+                request_key = crypto.createHash('md5').update(request_key).digest("hex");
+                var cache_key = modelName +'_' + request_key;
                 // search for cache
                 client.get(cache_key, function(err, val) {
                     if(err){
@@ -80,15 +86,15 @@ module.exports = function(Model, options) {
                         next();
                     }else{
                         next();
-                    }               
-                });    
+                    }
+                });
 
             }else{
                 next();
             }
         }else{
             next();
-        }        
+        }
     });
 
     Model.afterRemote('**', function(ctx, res, next) {
@@ -96,7 +102,7 @@ module.exports = function(Model, options) {
         if((ctx.method.name.indexOf("find") == -1 && ctx.method.name.indexOf("__get") == -1) && client.connected){
             var modelName = ctx.method.sharedClass.name;
             var cachExpire = ctx.req.query.cache;
-            
+
             // set key name
             var cache_key = modelName+'_*';
 
@@ -113,6 +119,6 @@ module.exports = function(Model, options) {
 
         }else{
             next();
-        }    
+        }
     });
 }

--- a/rediscache.js
+++ b/rediscache.js
@@ -32,9 +32,9 @@ module.exports = function(Model, options) {
 
                 // set key name
                 var crypto = require('crypto');
-                var request_key = new Buffer(JSON.stringify(ctx.req.query)).toString('base64');
+                var request_key = JSON.stringify(ctx.req.query).toString();
                 request_key = crypto.createHash('md5').update(request_key).digest("hex");
-                var cache_key = modelName +'_' + request_key;
+                var cache_key = modelName + request_key;
 
                 // search for cache
                 client.get(cache_key, function(err, val) {
@@ -70,9 +70,9 @@ module.exports = function(Model, options) {
 
                 // set key name
                 var crypto = require('crypto');
-                var request_key = new Buffer(JSON.stringify(ctx.req.query)).toString('base64');
+                var request_key = JSON.stringify(ctx.req.query).toString();
                 request_key = crypto.createHash('md5').update(request_key).digest("hex");
-                var cache_key = modelName +'_' + request_key;
+                var cache_key = modelName + request_key;
                 // search for cache
                 client.get(cache_key, function(err, val) {
                     if(err){
@@ -104,7 +104,7 @@ module.exports = function(Model, options) {
             var cachExpire = ctx.req.query.cache;
 
             // set key name
-            var cache_key = modelName+'_*';
+            var cache_key = modelName+'*';
 
             // delete cache
             redisDeletePattern({


### PR DESCRIPTION
I use relatively long model names and tons of parameters. Shorter keys maybe better by calc. md5 of request key. Underscore (_) at the key caused problems with matching. Idk if you had it too..

So its now: modelName{md5} and remove key is: modelName*